### PR TITLE
Add static Perplexité-inspired landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# Finance
+# Interface Perplexité (maquette)
+
+Cette maquette statique recrée l'expérience utilisateur de l'interface web de Perplexity en français.
+
+## Aperçu
+
+- Page d'accueil avec bandeau de navigation, zone de recherche et suggestions.
+- Bloc "Résultats" présentant des synthèses et leurs sources.
+- Volet latéral avec les sujets tendances et simulation de conversation continue.
+- Interactions front-end légères en JavaScript pour simuler une recherche et l'envoi de messages.
+
+## Utilisation
+
+Ouvrez simplement `index.html` dans votre navigateur. Aucun serveur n'est requis, tous les styles et scripts sont chargés localement.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Perplexité – Recherche assistée par IA</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="background-gradient"></div>
+    <header class="app-header">
+      <div class="logo">
+        <span class="logo-icon">?</span>
+        <span class="logo-text">Perplexité</span>
+      </div>
+      <nav class="main-nav">
+        <a href="#" class="nav-link active">Accueil</a>
+        <a href="#" class="nav-link">Découvrir</a>
+        <a href="#" class="nav-link">Bibliothèque</a>
+        <a href="#" class="nav-link">Projets</a>
+      </nav>
+      <div class="nav-actions">
+        <button class="btn ghost">Se connecter</button>
+        <button class="btn primary">Essayer Pro</button>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <section class="search-panel">
+        <div class="search-header">
+          <div>
+            <h1>Explorez n'importe quel sujet en quelques secondes</h1>
+            <p>
+              Posez vos questions, découvrez des sources fiables et obtenez des
+              réponses synthétiques, le tout propulsé par l'intelligence
+              artificielle.
+            </p>
+          </div>
+          <div class="search-metrics">
+            <div class="metric">
+              <span class="metric-value">98%</span>
+              <span class="metric-label">de satisfaction</span>
+            </div>
+            <div class="metric">
+              <span class="metric-value">4.8</span>
+              <span class="metric-label">note moyenne</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="search-box">
+          <span class="search-icon">🔍</span>
+          <input
+            type="text"
+            placeholder="Demandez n'importe quoi..."
+            aria-label="Champ de recherche"
+          />
+          <button class="btn primary">Rechercher</button>
+        </div>
+
+        <div class="search-tags">
+          <span>Suggestions :</span>
+          <button class="tag" data-query="Qu'est-ce que le machine learning ?">
+            Machine learning
+          </button>
+          <button class="tag" data-query="Dernières tendances IA 2024">
+            IA 2024
+          </button>
+          <button class="tag" data-query="Comment fonctionne la blockchain ?">
+            Blockchain
+          </button>
+          <button class="tag" data-query="Meilleurs livres sur la finance comportementale">
+            Finance comportementale
+          </button>
+        </div>
+      </section>
+
+      <section class="content-grid">
+        <article class="card highlights">
+          <h2>Résultats en vedette</h2>
+          <div class="result-item">
+            <div class="result-badge">Synthèse</div>
+            <h3>Comprendre le rôle de l'IA générative en entreprise</h3>
+            <p>
+              L'IA générative transforme la manière dont les organisations
+              innovent en automatisant la création de contenu, en accélérant la
+              recherche et en personnalisant les expériences clients.
+            </p>
+            <ul class="sources">
+              <li><a href="#">MIT Technology Review</a></li>
+              <li><a href="#">Harvard Business Review</a></li>
+              <li><a href="#">OECD AI Policy</a></li>
+            </ul>
+          </div>
+          <div class="result-item">
+            <div class="result-badge">Analyse</div>
+            <h3>Impact de l'IA sur le marché du travail</h3>
+            <p>
+              Selon les dernières études, l'IA est susceptible de redéfinir
+              près de 40&nbsp;% des métiers en automatisant les tâches
+              répétitives tout en créant de nouvelles opportunités.
+            </p>
+            <ul class="sources">
+              <li><a href="#">World Economic Forum</a></li>
+              <li><a href="#">OCDE</a></li>
+            </ul>
+          </div>
+        </article>
+
+        <aside class="card sidebar">
+          <h2>Tendance aujourd'hui</h2>
+          <ul class="trend-list">
+            <li class="trend-item">
+              <div>
+                <span class="trend-rank">1</span>
+                <span class="trend-topic">Fusion nucléaire : les dernières avancées</span>
+              </div>
+              <button class="icon-button" data-query="Fusion nucléaire dernières avancées">
+                ↗
+              </button>
+            </li>
+            <li class="trend-item">
+              <div>
+                <span class="trend-rank">2</span>
+                <span class="trend-topic">L'IA dans la santé prédictive</span>
+              </div>
+              <button class="icon-button" data-query="IA santé prédictive">
+                ↗
+              </button>
+            </li>
+            <li class="trend-item">
+              <div>
+                <span class="trend-rank">3</span>
+                <span class="trend-topic">Crédit carbone pour PME</span>
+              </div>
+              <button class="icon-button" data-query="Crédit carbone pour PME">
+                ↗
+              </button>
+            </li>
+            <li class="trend-item">
+              <div>
+                <span class="trend-rank">4</span>
+                <span class="trend-topic">Finance décentralisée expliquée</span>
+              </div>
+              <button class="icon-button" data-query="Finance décentralisée expliquée">
+                ↗
+              </button>
+            </li>
+          </ul>
+        </aside>
+
+        <section class="card conversation">
+          <div class="conversation-header">
+            <h2>Conversation en cours</h2>
+            <button class="btn ghost">Nouveau fil</button>
+          </div>
+          <div class="chat-bubble user">
+            <span class="avatar">TU</span>
+            <div>
+              <p>
+                Peux-tu me donner un plan d'apprentissage pour comprendre la
+                finance comportementale ?
+              </p>
+              <span class="timestamp">Tu – il y a 2 min</span>
+            </div>
+          </div>
+          <div class="chat-bubble assistant">
+            <span class="avatar">IA</span>
+            <div>
+              <p>
+                Bien sûr ! Voici une feuille de route qui couvre les concepts
+                clés, des lectures recommandées et des cas pratiques pour
+                appliquer tes connaissances.
+              </p>
+              <span class="timestamp">IA – il y a 1 min</span>
+            </div>
+          </div>
+          <div class="chat-input">
+            <input
+              type="text"
+              placeholder="Poursuivre la conversation..."
+              aria-label="Message"
+            />
+            <button class="btn primary">Envoyer</button>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <div class="footer-links">
+        <a href="#">À propos</a>
+        <a href="#">Confidentialité</a>
+        <a href="#">Conditions</a>
+        <a href="#">Centre d'aide</a>
+      </div>
+      <span class="footer-copy">© 2024 Perplexité, Inc.</span>
+    </footer>
+
+    <div class="floating-action">
+      <button class="btn primary" id="quick-question">Poser une question</button>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,54 @@
+const searchInput = document.querySelector('.search-box input');
+const searchButton = document.querySelector('.search-box .btn');
+const quickQuestionButton = document.getElementById('quick-question');
+const chatInput = document.querySelector('.chat-input input');
+const chatSendButton = document.querySelector('.chat-input .btn');
+
+function setQueryFromElement(element) {
+  const query = element?.dataset?.query;
+  if (!query) return;
+
+  searchInput.value = query;
+  searchInput.focus();
+}
+
+document.querySelectorAll('[data-query]').forEach((element) => {
+  element.addEventListener('click', () => setQueryFromElement(element));
+});
+
+searchButton.addEventListener('click', () => {
+  const value = searchInput.value.trim();
+  if (!value) {
+    searchInput.focus();
+    searchInput.classList.add('shake');
+    setTimeout(() => searchInput.classList.remove('shake'), 400);
+    return;
+  }
+
+  alert(`Simulation Perplexité\n\nVous avez recherché : "${value}"`);
+});
+
+quickQuestionButton.addEventListener('click', () => {
+  searchInput.focus();
+  searchInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
+});
+
+chatSendButton.addEventListener('click', () => {
+  const value = chatInput.value.trim();
+  if (!value) {
+    chatInput.focus();
+    chatInput.classList.add('shake');
+    setTimeout(() => chatInput.classList.remove('shake'), 400);
+    return;
+  }
+
+  alert('Simulation de réponse IA :\n\n' + value);
+  chatInput.value = '';
+});
+
+chatInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    chatSendButton.click();
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,522 @@
+:root {
+  --bg: #060712;
+  --surface: rgba(16, 18, 35, 0.9);
+  --surface-light: rgba(255, 255, 255, 0.04);
+  --surface-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f5f6ff;
+  --text-secondary: #b5b8d3;
+  --accent: #4c8bff;
+  --accent-strong: #7aa2ff;
+  --success: #3be5c3;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text-primary);
+  min-height: 100vh;
+  position: relative;
+  padding-bottom: 64px;
+}
+
+.background-gradient {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(76, 139, 255, 0.28), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(59, 229, 195, 0.18), transparent 40%);
+  z-index: -1;
+}
+
+.app-header,
+.app-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 64px;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(12px);
+  background: rgba(6, 7, 18, 0.75);
+  border-bottom: 1px solid var(--surface-border);
+  z-index: 20;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.logo-icon {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--accent), var(--success));
+  color: #02040c;
+  font-weight: 700;
+}
+
+.main-nav {
+  display: flex;
+  gap: 20px;
+}
+
+.nav-link {
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+  color: var(--text-primary);
+}
+
+.nav-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #02040c;
+  box-shadow: 0 8px 16px rgba(76, 139, 255, 0.35);
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px solid var(--surface-border);
+  color: var(--text-secondary);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.main-content {
+  padding: 48px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.search-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 24px;
+  padding: 32px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.search-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.search-header h1 {
+  font-size: 2.4rem;
+  line-height: 1.2;
+  margin-bottom: 12px;
+}
+
+.search-header p {
+  color: var(--text-secondary);
+  max-width: 520px;
+  line-height: 1.6;
+}
+
+.search-metrics {
+  display: flex;
+  gap: 16px;
+}
+
+.metric {
+  background: var(--surface-light);
+  border: 1px solid var(--surface-border);
+  padding: 16px 20px;
+  border-radius: 18px;
+  min-width: 130px;
+  text-align: center;
+}
+
+.metric-value {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--success);
+}
+
+.metric-label {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.search-box {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  background: var(--surface-light);
+  border: 1px solid var(--surface-border);
+  border-radius: 999px;
+  padding: 12px 16px 12px 20px;
+}
+
+.search-box input.shake,
+.chat-input input.shake {
+  animation: shake 0.4s ease;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20%,
+  60% {
+    transform: translateX(-6px);
+  }
+  40%,
+  80% {
+    transform: translateX(6px);
+  }
+}
+
+.search-icon {
+  font-size: 1.4rem;
+}
+
+.search-box input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1rem;
+  outline: none;
+}
+
+.search-tags {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: var(--text-secondary);
+}
+
+.tag {
+  background: transparent;
+  border: 1px solid var(--surface-border);
+  border-radius: 999px;
+  padding: 8px 16px;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.tag:hover {
+  background: rgba(76, 139, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 24px;
+  padding: 28px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28);
+}
+
+.highlights h2,
+.sidebar h2,
+.conversation h2 {
+  margin-bottom: 18px;
+  font-size: 1.4rem;
+}
+
+.result-item + .result-item {
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid var(--surface-border);
+}
+
+.result-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(76, 139, 255, 0.18);
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.result-item h3 {
+  margin-bottom: 8px;
+}
+
+.result-item p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.sources {
+  list-style: none;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.sources a {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.trend-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.trend-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--surface-light);
+  border: 1px solid var(--surface-border);
+  border-radius: 16px;
+  padding: 12px 16px;
+  gap: 16px;
+}
+
+.trend-rank {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(76, 139, 255, 0.2);
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.trend-topic {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.icon-button {
+  background: rgba(76, 139, 255, 0.14);
+  border: none;
+  border-radius: 12px;
+  color: var(--accent-strong);
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: background 0.2s ease;
+}
+
+.icon-button:hover {
+  background: rgba(76, 139, 255, 0.24);
+}
+
+.conversation {
+  grid-column: span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.conversation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chat-bubble {
+  display: flex;
+  gap: 16px;
+  background: var(--surface-light);
+  border: 1px solid var(--surface-border);
+  border-radius: 20px;
+  padding: 16px 20px;
+}
+
+.chat-bubble.user {
+  border-left: 3px solid var(--accent);
+}
+
+.chat-bubble.assistant {
+  border-left: 3px solid var(--success);
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(76, 139, 255, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.timestamp {
+  display: block;
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.chat-input {
+  display: flex;
+  gap: 12px;
+  background: var(--surface-light);
+  border: 1px solid var(--surface-border);
+  border-radius: 999px;
+  padding: 10px 12px 10px 20px;
+}
+
+.chat-input input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  outline: none;
+}
+
+.app-footer {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--surface-border);
+  background: rgba(6, 7, 18, 0.85);
+  backdrop-filter: blur(12px);
+}
+
+.footer-links {
+  display: flex;
+  gap: 16px;
+}
+
+.footer-links a {
+  text-decoration: none;
+  color: inherit;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: var(--text-primary);
+}
+
+.floating-action {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+}
+
+@media (max-width: 1200px) {
+  .main-content {
+    padding: 32px;
+  }
+
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .conversation {
+    grid-column: auto;
+  }
+
+  .search-header {
+    flex-direction: column;
+  }
+
+  .search-metrics {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-header,
+  .app-footer {
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px 24px;
+  }
+
+  .main-nav,
+  .nav-actions {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .main-content {
+    padding: 24px;
+  }
+
+  .search-panel {
+    padding: 24px;
+  }
+
+  .search-box {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-box button {
+    width: 100%;
+  }
+
+  .chat-input {
+    flex-direction: column;
+  }
+
+  .chat-input button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- create a static HTML page that mirrors the main Perplexity layout with hero search, highlights, trends, and conversation blocks
- add modern styling with responsive layout, glassmorphism surfaces, and interactive hover/animation effects
- implement lightweight JavaScript interactions for quick query filling, simulated search alerts, and chat send feedback
- document the project structure and usage instructions in French

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e014b726408332a7274658f46027f2